### PR TITLE
Changing GetSerializedSetting exception trace message to include the key which was trying to be loaded.

### DIFF
--- a/Configuration/ConfigDirectorySettings.cs
+++ b/Configuration/ConfigDirectorySettings.cs
@@ -108,8 +108,9 @@ namespace Its.Configuration
                                             catch (CryptographicException exception)
                                             {
                                                 Trace.WriteLine(string.Format(
-                                                    "Handled exception while trying to load certificate {0}: {1}",
+                                                    "Handled exception while trying to load certificate {0} for key {1}: {2}",
                                                     f.FullName,
+                                                    key,
                                                     exception));
                                             }
 


### PR DESCRIPTION
Added to the CryptographicException Handled exception trace message which key was trying to be loaded in the call to ConfigDirectorySettings.GetSerializedSettings