### PR TITLE
Update Its.Configuration nuspec for case sensitivity

### DIFF
--- a/Configuration/Its.Configuration.nuspec
+++ b/Configuration/Its.Configuration.nuspec
@@ -12,7 +12,7 @@
     <description>App configuration for .NET. Strong-typed, JSON file-based, host-independent, and manageable.</description>
     <tags>configuration encryption Azure</tags>
     <dependencies>
-      <dependency id="NewtonSoft.Json" version="[6.0.8,)" />
+      <dependency id="Newtonsoft.Json" version="[6.0.8,)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Noticed that vNext gets picky about case sensitivity on dependencies. This helps.