### PR TITLE
Always close the X509Store in CryptographyExtensions.Decrypt

### DIFF
--- a/Configuration/CryptographyExtensions.cs
+++ b/Configuration/CryptographyExtensions.cs
@@ -42,8 +42,16 @@ namespace Its.Configuration
             var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
 
             store.Open(OpenFlags.ReadOnly);
-            
-            var certCollection = store.Certificates;
+
+            X509Certificate2Collection certCollection;
+            try
+            {
+                certCollection = store.Certificates;
+            }
+            finally
+            {
+                store.Close();
+            }
 
             if (certificates != null && certificates.Length > 0)
             {


### PR DESCRIPTION
I have been told that this may be a factor in our intermittent cert
loading issues.